### PR TITLE
fix regression from 'add prompt for jQuery or Zepto' #32

### DIFF
--- a/app/templates/_Gruntfile.js
+++ b/app/templates/_Gruntfile.js
@@ -201,7 +201,8 @@ module.exports = function(grunt) {
         }
       ],
       paths: {
-        'jquery': '../bower_components/jquery/jquery',
+        <% if (!useZepto) { %>'jquery': '../bower_components/jquery/jquery',<% } %>
+        <% if (useZepto) { %>'zepto': '../bower_components/zepto/zepto',<% } %>
         'underscore': '../bower_components/underscore/underscore',
         'handlebars': '../bower_components/handlebars/handlebars.runtime',
         'backbone': '../bower_components/backbone/backbone',
@@ -230,7 +231,8 @@ module.exports = function(grunt) {
         },
         'backbone': {
           exports: 'Backbone',
-          deps: ['jquery', 'underscore']
+        <% if (!useZepto) { %>deps: ['jquery', 'underscore']<% } %>
+        <% if (useZepto) { %>deps: ['zepto', 'underscore']<% } %>
         },
         'underscore': {
           exports: '_'
@@ -240,8 +242,15 @@ module.exports = function(grunt) {
           deps: ['handlebars', 'backbone']
         },
         'bootstrap': {
-          deps: ['jquery']
+        <% if (!useZepto) { %>deps: ['jquery']<% } %>
+        <% if (useZepto) { %>deps: ['zepto']<% } %>
         }
+        <% if (useZepto) { %>
+        ,
+        'zepto': {
+          exports: '$'
+        }
+        <% } %>
       }
     };
     if (env === 'production') {

--- a/app/templates/_main.js
+++ b/app/templates/_main.js
@@ -1,6 +1,6 @@
 require([
-  '<% if (!useZepto) { %>jquery,<% } %>'
-  '<% if (useZepto) { %>zepto,<% } %>'
+  <% if (!useZepto) { %>'jquery',<% } %>
+  <% if (useZepto) { %>'zepto',<% } %>
   'backbone',
   '<% if (includeCoffeeScript) { %>cs!<% } %>views/root'<% if (starterApp === 'Hello World') { %>,
   '<% if (includeCoffeeScript) { %>cs!<% } %>routers/hello-world'<% } else if (starterApp === 'Todo List') { %>,

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -302,7 +302,10 @@ describe('thorax generator', function () {
       it('is included when selected in the prompt', function (done) {
         helpers.assertFiles([
           ['bower.json', /jquery/],
-          ['js/main.js', /jquery/]
+          ['js/main.js', /jquery/],
+          ['Gruntfile.js', /bower_components\/jquery\/jquery/],
+          ['Gruntfile.js', /deps: \['jquery', 'underscore'\]/],
+          ['Gruntfile.js', /deps: \['jquery'\]/]
         ]);
         done();
       });
@@ -316,7 +319,11 @@ describe('thorax generator', function () {
       it('is included when selected in the prompt', function (done) {
         helpers.assertFiles([
           ['bower.json', /zepto/],
-          ['js/main.js', /zepto/]
+          ['js/main.js', /zepto/],
+          ['Gruntfile.js', /bower_components\/zepto\/zepto/],
+          ['Gruntfile.js', /deps: \['zepto', 'underscore'\]/],
+          ['Gruntfile.js', /deps: \['zepto'\]/],
+          ['Gruntfile.js', /exports: '\$'/]
         ]);
         done();
       });


### PR DESCRIPTION
- fix where comma is located in min.'s template
- add zepto bower path to Gruntfile
- backbone should depend on backbone or zepto in Gruntfile
- bootstrap should depend on zepto or query
- shim zepto, export $
- add tests for the above functionality

/cc @ryan-roemer, @eastridge 
