### PR TITLE
Enable live reload support

### DIFF
--- a/app/templates/_Gruntfile.js
+++ b/app/templates/_Gruntfile.js
@@ -2,6 +2,7 @@ module.exports = function(grunt) {
   grunt.option('stack', true);
 
   var port = process.env.PORT || 8000,
+      liveReloadPort = 35729,
       hostname = 'localhost',
       templates = {},
       paths = {
@@ -78,7 +79,14 @@ module.exports = function(grunt) {
         options: {
           hostname: hostname,
           base: paths.public,
-          port: port
+          port: port,
+          middleware: function (connect, options) {
+            return [
+              require('connect-livereload')({port: liveReloadPort}),
+              connect['static'](options.base),
+              connect.directory(options.base)
+            ];
+          }
         }
       },
       production:  {
@@ -169,6 +177,10 @@ module.exports = function(grunt) {
       }
     },<% } %>
     watch: {
+      options: {
+        livereload: liveReloadPort,
+        files: ['public/**/*']
+      },
       handlebars: {
         files: [paths.templates + '/**/*.hbs'],
         tasks: ['templates']
@@ -316,7 +328,7 @@ module.exports = function(grunt) {
     'styles',
     'templates',
     'scripts:development',
-    'thorax:inspector',
+    // 'thorax:inspector', // shared port 35729 w/ livereload
     'connect:development',
     'open-browser',
     'watch'

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "dependencies": {},
   "devDependencies": {
-    "grunt-contrib-connect": "0.1.1",
+    "grunt-contrib-connect": "0.3.0",
     "grunt": "~0.4",
     "thorax-inspector": "0.2.4",
     "open": "0.0.3",
@@ -13,7 +13,7 @@
     "grunt-contrib-clean": "~0.5.0",
     "matchdep": "~0.1.2",
     "grunt-cli": "~0.1.9",
-    "grunt-contrib-watch": "~0.5.1",
+    "grunt-contrib-watch": "~0.5.3",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-requirejs": "~0.4.1",
     "grunt-contrib-handlebars": "~0.5.10",


### PR DESCRIPTION
- this commit disables thorax inspector to show that it seems to be the culprit. 

Thorax inspector seems to prevent the following file from working properly:
https://github.com/mklabs/tiny-lr/blob/master/lib/public/livereload.js, which is used by grunt contrib watch(which acts as a livereload server)

/cc @eastridge
