### PR TITLE
Enable live reload for handlebar templates

### DIFF
--- a/app/templates/_Gruntfile.js
+++ b/app/templates/_Gruntfile.js
@@ -182,8 +182,8 @@ module.exports = function(grunt) {
         files: ['public/**/*']
       },
       handlebars: {
-        files: [paths.templates + '/**/*.hbs'],
-        tasks: ['templates']
+        files: [paths.templates + '/**/*.hbs', paths.templates + '/**/*.handlebars'],
+        tasks: ['templates', 'scripts:development']
       <% if (includeCoffeeScript) { %>},
       coffee: {
         files: paths.js + '/**/*.coffee',


### PR DESCRIPTION
This is a pretty simple change to the template Gruntfile:

Watch for changes to handlebar files.
Run the scripts task after templates are compiled.

With this change, live reload happens after you edit a handlebars template.
