### PR TITLE
additional test helpers

### DIFF
--- a/test/shared-examples.js
+++ b/test/shared-examples.js
@@ -1,0 +1,12 @@
+// js version of https://relishapp.com/rspec/rspec-core/v/3-0/docs/example-groups/shared-examples
+
+sharedExamples = {};
+
+module.exports = {
+  create: function(methodName, methodBody) {
+    sharedExamples[methodName] = methodBody;
+  },
+  invoke: function(methodName) {
+    sharedExamples[methodName]();
+  }
+};

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -3,6 +3,35 @@ var path    = require('path');
 var chai = require('chai');
 var expect = chai.expect;
 var helpers = require('yeoman-generator').test;
+var fs = require('fs');
+var sharedExamples = require('./shared-examples');
+
+var assert = chai.assert;
+
+helpers.assertNoFile = function (file, reg) {
+  var here = fs.existsSync(file);
+  assert.ok(!here, file + 'DOES exist, something is wrong');
+
+  if (!reg) {
+    return assert.ok(!here);
+  }
+
+  var body = fs.readFileSync(file, 'utf8');
+  assert.ok(!reg.test(body), file + ' DID MATCH, HOLD THE PHONE: match \'' + reg + '\'.');
+};
+
+
+helpers.assertFileHasNoContent = function(file, reg) {
+  var here = fs.existsSync(file);
+  assert.ok(here, file + ' does exist, we expected that');
+
+  if (!reg) {
+    return assert.fail('You must provide content via regex for this helper');
+  }
+
+  var body = fs.readFileSync(file, 'utf8');
+  assert.ok(!reg.test(body), file + ' DID MATCH, STAHP!, control flow the following content or fix the test: match \'' + reg + '\'.');
+}
 
 describe('thorax generator', function () {
   beforeEach(function (done) {


### PR DESCRIPTION
- assertNoFile: asserts that a file does not exist, test will fail
  if the file is present
- assertFileHasNoContent: asserts that a particular file does not
  have the content provided in the regex
- sharedExamples: allows re-use of common examples in test to help
  remove duplication and ease the burden in control flow branches when
  building the generator. Use sparingly. If used a lot, perhaps the
  generator is to complicated and should be re-thought at a higher level

/cc @eastridge, @ryan-roemer - let me know if these are okay to add. I am using them as i pull in testing stuff so I figured they we're useful on their own. I'm not sure if they should stay around for the long term but refactoring the generator while adding the testing stuff is much faster this way
