### PR TITLE
add .sass-cache to generated gitignore

### DIFF
--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -4,3 +4,4 @@ public/css
 public/js
 tmp
 coverage/
+.sass-cache


### PR DESCRIPTION
will be applied for every generated app, but this that’s no biggie

fixes #79
