### PR TITLE
reduce file size of dist/main.js

### DIFF
--- a/app/templates/seed/tasks/options/requirejs.js
+++ b/app/templates/seed/tasks/options/requirejs.js
@@ -7,6 +7,8 @@ module.exports = {
       // mainConfigFile: 'tmp/main.build.js', // wont work :/ see TODO: remove build duplication
       name: '../bower_components/almond/almond',
       include: ['main'],
+      exclude: ['coffee-script'],
+      stubModules: ['cs'],
       out: 'dist/main.js',
       removeCombined: true,
       findNestedDependencies: true,


### PR DESCRIPTION
reduce file size of compiled dist/main.js during production build by removing coffeescript/stubbing cs module
