### PR TITLE
re-add marked as a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "grunt-mocha": "~0.4.0",
     "grunt-contrib-copy": "~0.4.1",
     "mocha": "~1.10.0",
+    "marked": "~0.2.10",
     "sinon": "~1.7.3"
   },
   "engines": {


### PR DESCRIPTION
Error when running Grunt before change: 

Running "ensure-installed" task
bower downloading http://sinonjs.org/releases/sinon-1.7.3.js
...
bower checking out text#2.0.10
Fatal error: Invalid Version: 6d6c5e08a1295fee047849abbad927c7f0de99bd

Fixed with this change. 
