### PR TITLE
Make grunt watch faster

### DIFF
--- a/app/templates/seed/tasks/options/watch.js
+++ b/app/templates/seed/tasks/options/watch.js
@@ -4,7 +4,8 @@ module.exports = {
   options: { // livereload will run after all watch tasks finish
     livereload: grunt.config('settings.liveReloadPort'),
     debounceDelay: 0,
-    interval: 20
+    interval: 100,
+    spawn: false
   },
   styles: { // watch all styles and rebuild when change
     files: [grunt.config('paths.css') + '/**/*.{css,sass,scss,less,styl}'],


### PR DESCRIPTION
By not spawning a new process for tasks run by watch.

Way way faster livereload action is the main benefit here, its awesome

/cc @eastridge
