### PR TITLE
don’t run travis for node 0.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
-  - "0.11"
   - "0.10"
   - "0.8"


### PR DESCRIPTION
this is completely optional but makes sense consider 0.11 is the
non stable branch of node that only people who work on node itself
actively use, and b/c travis seems to fail about 80% of the time when
installing npm deps for v0.11

/cc @eastridge
