### PR TITLE
Grunt watch should not always run karma:server:run

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -238,6 +238,7 @@ ThoraxGenerator.prototype.app = function () {
   this.mkdir('tasks');
   this.copy('seed/tasks/ensure-installed.js', 'tasks/ensure-installed.js');
   this.copy('seed/tasks/styles.js', 'tasks/styles.js');
+  this.copy('seed/tasks/add-karma-to-watch.js', 'tasks/add-karma-to-watch.js');
 
   this.mkdir('tasks/options');
   this.copy('seed/tasks/options/clean.js', 'tasks/options/clean.js');

--- a/app/templates/_Gruntfile.js
+++ b/app/templates/_Gruntfile.js
@@ -101,6 +101,7 @@ module.exports = function(grunt) {
     'thorax:inspector',
     'karma:server',
     'connect:development',
+    'addKarmaToWatchTask',
     'watch'
   ]);
 

--- a/app/templates/seed/tasks/add-karma-to-watch.js
+++ b/app/templates/seed/tasks/add-karma-to-watch.js
@@ -1,0 +1,14 @@
+var grunt = require('grunt');
+
+/**
+ * Appends 'karma:server:run' to the scripts configuration
+ * object of the watch task.
+ */
+grunt.registerTask('addKarmaToWatchTask', function() {
+  grunt.util._.forIn(grunt.config('watch'), function(config, key) {
+    if (key === 'scripts') {
+      config.tasks.push('karma:server:run');
+      grunt.config('watch.' + key, config);
+    }
+  });
+});

--- a/app/templates/seed/tasks/options/karma.js
+++ b/app/templates/seed/tasks/options/karma.js
@@ -3,7 +3,8 @@ module.exports = {
     configFile: 'karma.conf.js'
   },
   server: {
-    background: true
+    background: true,
+    autoWatch: false
   },
   ci: {
     singleRun: true,

--- a/app/templates/seed/tasks/options/watch.js
+++ b/app/templates/seed/tasks/options/watch.js
@@ -17,7 +17,7 @@ module.exports = {
       'test/**/*',
       'require-config.js'
     ],
-    tasks: ['jshint:all', 'karma:server:run']
+    tasks: ['jshint:all']
   },
   other: { // images, fonts change? livereload browser
     files: [

--- a/test/thorax-generator.spec.js
+++ b/test/thorax-generator.spec.js
@@ -79,6 +79,7 @@ describe('Thorax Generator (yo thorax:app NAME)', function () {
       'public/index.html',
       'css/base.css',
       'tasks/ensure-installed.js',
+      'tasks/add-karma-to-watch.js',
       'tasks/styles.js',
       'tasks/options/clean.js',
       'tasks/options/connect.js',


### PR DESCRIPTION
currently grunt watch runs karma:server:run whenever a js file
changes even if karma is not running, or even worse,
when you've chosen to run karma separately via karma start.

This change has grunt watch run the karma:server:run task when
running the grunt autotest task

/cc @eastridge
