### PR TITLE
remove-thorax-inspector-dep-annoyance

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "grunt-contrib-connect": "~0.5.0",
     "grunt": "~0.4",
-    "thorax-inspector": "0.2.7",
+    "thorax-inspector": "~0.2.0",
     "bower": "~0.10",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-clean": "~0.5.0",


### PR DESCRIPTION
fixes #102

/cc @eastridge - before pulling this version bump
https://github.com/eastridge/thorax-inspector-backend
otherwise this PR won’t fix much of anything

also note I’m using the ~ instead of the hard dependency. no reason not
to (AFAIK)
