### PR TITLE
Remove support for node 0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
   - "0.10"
-  - "0.8"


### PR DESCRIPTION
yoeman-generator recently dropped support for anything but node 0.10
which is why travis is failing and we have been blocked on pulling new PR's

https://github.com/yeoman/generator/issues/469

fixes #122 

/cc @eastridge 
