### PR TITLE
add require("./test-setup-all") to test-setup-browser

### DIFF
--- a/app/templates/seed/test/test-setup-browser.js
+++ b/app/templates/seed/test/test-setup-browser.js
@@ -14,6 +14,8 @@ define(function(require) {
   global.mocha.setup('bdd');
   global.mocha.reporter('html');
 
+  require("./test-setup-all");
+
   require([ // require test files
     '<% if (includeCoffeeScript) { %>cs!<% } %>./app.spec',
     '<% if (includeCoffeeScript) { %>cs!<% } %>./views/root.spec',


### PR DESCRIPTION
b/c it wasn't being loaded in an async friendly way

use case: if your remove some of the default required files in test-setup-browser
the async call will take less time and expose the bug. this fixes that

/cc @eastridge
